### PR TITLE
chore(release): 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 * Updated to be compatible with Dart 3
 
+## [1.0.1](https://github.com/vlnevyhosteny/buttercms-dart/compare/v2.0.1...v1.0.1) (2023-11-06)
+
+
+### Features
+
+* Added example to package ([3dd1e27](https://github.com/vlnevyhosteny/buttercms-dart/commit/3dd1e277dda33fbcf7225514cea7207d821f5b6c))
+* Changed design pattern (named params -&gt; optional param map) ([236d698](https://github.com/vlnevyhosteny/buttercms-dart/commit/236d6983536861430f7ccc993c5d4ccf5a2906f4))
+* release please with publish ([1320caa](https://github.com/vlnevyhosteny/buttercms-dart/commit/1320caad41fb0d8e8e11a6c49ff0df86d1367007))
+* Removed Flutter dependency ([8f2272c](https://github.com/vlnevyhosteny/buttercms-dart/commit/8f2272c947755e9c387a6cf2723fcaf9ff9a1d3e))
+* upgrade to be compatible with Dart 3 ([5426af5](https://github.com/vlnevyhosteny/buttercms-dart/commit/5426af50ed7ecc599e62ab03f5274c952c37a8dc))
+
+
+### Bug Fixes
+
+* add secret token to release-please wf to trigger other workflows ([3ffd455](https://github.com/vlnevyhosteny/buttercms-dart/commit/3ffd4551f47366dc1b94eb378aa5082de978cabd))
+* Corrected README ([659c1b8](https://github.com/vlnevyhosteny/buttercms-dart/commit/659c1b857913eabab23e6e3814aa8ca13694f6a4))
+* Corrected README ([e271d85](https://github.com/vlnevyhosteny/buttercms-dart/commit/e271d85d3dcb59134aed75d9b7f5775df43dd007))
+* warning and hints from dart publish dry run ([a3b89d4](https://github.com/vlnevyhosteny/buttercms-dart/commit/a3b89d4a845e5ad8fb755b79d9b8c064c36b84db))
+
 ## [0.1.1] - 17/06/2020
 
 * Fixes blog post search

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buttercms_dart
 description: The official ButterCMS package for Flutter. Use the full feature set Butter offers, now available on Flutter.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/ButterCMS/buttercms-dart
 
 environment:


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.1](https://github.com/vlnevyhosteny/buttercms-dart/compare/v2.0.1...v1.0.1) (2023-11-06)


### Features

* Added example to package ([3dd1e27](https://github.com/vlnevyhosteny/buttercms-dart/commit/3dd1e277dda33fbcf7225514cea7207d821f5b6c))
* Changed design pattern (named params -&gt; optional param map) ([236d698](https://github.com/vlnevyhosteny/buttercms-dart/commit/236d6983536861430f7ccc993c5d4ccf5a2906f4))
* release please with publish ([1320caa](https://github.com/vlnevyhosteny/buttercms-dart/commit/1320caad41fb0d8e8e11a6c49ff0df86d1367007))
* Removed Flutter dependency ([8f2272c](https://github.com/vlnevyhosteny/buttercms-dart/commit/8f2272c947755e9c387a6cf2723fcaf9ff9a1d3e))
* upgrade to be compatible with Dart 3 ([5426af5](https://github.com/vlnevyhosteny/buttercms-dart/commit/5426af50ed7ecc599e62ab03f5274c952c37a8dc))


### Bug Fixes

* add secret token to release-please wf to trigger other workflows ([3ffd455](https://github.com/vlnevyhosteny/buttercms-dart/commit/3ffd4551f47366dc1b94eb378aa5082de978cabd))
* Corrected README ([659c1b8](https://github.com/vlnevyhosteny/buttercms-dart/commit/659c1b857913eabab23e6e3814aa8ca13694f6a4))
* Corrected README ([e271d85](https://github.com/vlnevyhosteny/buttercms-dart/commit/e271d85d3dcb59134aed75d9b7f5775df43dd007))
* warning and hints from dart publish dry run ([a3b89d4](https://github.com/vlnevyhosteny/buttercms-dart/commit/a3b89d4a845e5ad8fb755b79d9b8c064c36b84db))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).